### PR TITLE
feat: replace openwakeword with micro-wake-word streaming detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Private Assistant Communications Satellite is a latency-optimized edge devic
 
 ## 🎯 Key Features
 
-- **🔊 Real-time Wake Word Detection** - OpenWakeWord integration with customizable models
+- **🔊 Real-time Wake Word Detection** - micro-wake-word TFLite integration with customizable models
 - **🎤 Voice Activity Detection (VAD)** - Silero VAD for accurate speech boundary detection
 - **🗣️ Speech Processing Integration** - Async STT/TTS API communication
 - **📡 MQTT Ecosystem Integration** - Low-latency message passing with the assistant ecosystem
@@ -136,9 +136,8 @@ uv run comms-satellite config-template
 
 ```yaml
 # Wake word settings
-wakework_detection_threshold: 0.6
-path_or_name_wakeword_model: "./assets/wakeword_models/hey_nova.onnx"
-name_wakeword_model: "hey_nova"
+wakework_detection_threshold: 0.97
+wakeword_model_path: "./okay_nabu.tflite"
 
 # API endpoints - REQUIRED
 speech_transcription_api: "http://your-stt-server:8000/transcribe"
@@ -163,7 +162,6 @@ output_device_index: 1  # Your speaker
 ```yaml
 # Optimize for minimal CPU usage
 chunk_size: 1024        # Larger chunks = less CPU overhead
-chunk_size_ow: 1280     # OpenWakeWord optimized size
 samplerate: 16000       # Standard rate, good quality/performance balance
 vad_threshold: 0.7      # Higher threshold = less false positives
 vad_trigger: 2          # Require 2 chunks before activation
@@ -174,7 +172,6 @@ max_command_input_seconds: 10  # Shorter timeout saves memory
 ```yaml
 # Optimize for lower latency
 chunk_size: 512         # Smaller chunks = lower latency
-chunk_size_ow: 1280     # Keep OpenWakeWord optimized
 samplerate: 16000       # Can handle higher if needed
 vad_threshold: 0.6      # More sensitive detection
 vad_trigger: 1          # Immediate activation
@@ -378,11 +375,9 @@ output_topic_overwrite: "custom/satellite/living_room/speech_output"
 ```yaml
 # Lower latency (higher CPU usage)
 chunk_size: 256
-chunk_size_ow: 1280
 
 # Higher latency (lower CPU usage)
 chunk_size: 1024
-chunk_size_ow: 1280
 ```
 
 2. **VAD Sensitivity Tuning:**
@@ -531,6 +526,7 @@ private-assistant-comms-satellite-py/
 │   ├── cli.py                   # Command-line interface
 │   ├── main.py                  # Application entry point
 │   ├── satellite.py            # Core Satellite class (main logic)
+│   ├── micro_wake_word.py     # MicroWakeWord streaming detector
 │   ├── silero_vad.py           # Voice Activity Detection
 │   └── utils/
 │       ├── config.py           # Configuration management
@@ -573,7 +569,7 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 
 ## 🙏 Acknowledgments
 
-- **OpenWakeWord** - Wake word detection engine
+- **[micro-wake-word](https://github.com/OHF-Voice/micro-wake-word)** - Wake word detection models (TFLite)
 - **Silero VAD** - Voice activity detection
 - **Private Assistant Commons** - Shared utilities and message formats
 - **sounddevice** - Python audio I/O library with NumPy integration

--- a/docs/audio-processing-config.md
+++ b/docs/audio-processing-config.md
@@ -4,12 +4,12 @@ The satellite uses a two-stage audio enhancement pipeline optimized for wake wor
 1. **Parametric EQ** - Boosts speech clarity (3.5 kHz presence)
 2. **Automatic Gain Control (AGC)** - Normalizes volume levels
 
-**Important**: Filters are applied BEFORE wake word detection. Modifications affect OpenWakeWord's ability to detect patterns.
+**Important**: Filters are applied BEFORE wake word detection. Modifications affect MicroWakeWord's ability to detect patterns.
 
 ## Audio Pipeline Flow
 
 ```
-sounddevice → Parametric EQ → AGC → int16 conversion → OpenWakeWord → VAD → Recording
+sounddevice → Parametric EQ → AGC → int16 → MicroFrontend (spectrogram) → TFLite inference → VAD → Recording
 ```
 
 ## Parametric EQ for Voice Enhancement
@@ -32,7 +32,7 @@ audio_processing:
 **For nasal voice**: Lower presence frequency to 2500-3000 Hz
 **For minimal processing**: Set presence boost to 1-2 dB
 
-**Note**: This EQ only boosts mid-high frequencies (presence) which are critical for wake word detection. Low-frequency boosts interfere with OpenWakeWord's spectral pattern recognition.
+**Note**: This EQ only boosts mid-high frequencies (presence) which are critical for wake word detection. MicroWakeWord's MicroFrontend has built-in PCAN noise suppression at the feature level.
 
 ### Performance Impact
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,27 +8,25 @@
 ```yaml
 # Larger chunks reduce CPU overhead
 chunk_size: 1024
-chunk_size_ow: 1280
 
-# Higher thresholds reduce false positives  
+# Higher thresholds reduce false positives
 vad_threshold: 0.7
 vad_trigger: 2
-wakework_detection_threshold: 0.65
+wakework_detection_threshold: 0.97
 
 # Shorter timeouts save memory
 max_command_input_seconds: 10
 ```
 
 #### Raspberry Pi 4 (Latency-optimized)
-```yaml  
+```yaml
 # Smaller chunks for lower latency
 chunk_size: 512
-chunk_size_ow: 1280
 
 # More sensitive detection
 vad_threshold: 0.6
 vad_trigger: 1
-wakework_detection_threshold: 0.6
+wakework_detection_threshold: 0.97
 
 # Can handle longer commands
 max_command_input_seconds: 15

--- a/integration/__init__.py
+++ b/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the private assistant comms satellite."""

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,0 +1,58 @@
+"""Shared fixtures for integration tests."""
+
+import math
+import pathlib
+import urllib.request
+
+import numpy as np
+import piper
+import piper.download_voices as piper_download
+import pytest
+from scipy import signal
+
+_OKAY_NABU_URL = "https://github.com/esphome/micro-wake-word-models/raw/main/models/v2/okay_nabu.tflite"
+_PIPER_VOICE = "en_US-lessac-medium"
+_TARGET_SAMPLE_RATE = 16_000
+
+
+@pytest.fixture(scope="session")
+def model_cache_dir(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+    """Session-scoped directory for caching downloaded models."""
+    return tmp_path_factory.mktemp("models")
+
+
+@pytest.fixture(scope="session")
+def okay_nabu_model_path(model_cache_dir: pathlib.Path) -> pathlib.Path:
+    """Download and cache the okay_nabu v2 TFLite model."""
+    model_path = model_cache_dir / "okay_nabu.tflite"
+    if not model_path.exists():
+        urllib.request.urlretrieve(_OKAY_NABU_URL, model_path)
+    return model_path
+
+
+@pytest.fixture(scope="session")
+def piper_voice(model_cache_dir: pathlib.Path) -> piper.PiperVoice:
+    """Download and load a Piper TTS voice model."""
+    piper_download.download_voice(_PIPER_VOICE, model_cache_dir)
+    onnx_path = model_cache_dir / f"{_PIPER_VOICE}.onnx"
+    return piper.PiperVoice.load(str(onnx_path))
+
+
+def _resample(audio: np.ndarray, original_rate: int, target_rate: int) -> np.ndarray:
+    """Resample int16 audio using polyphase filtering."""
+    if original_rate == target_rate:
+        return audio
+    gcd = math.gcd(target_rate, original_rate)
+    resampled = signal.resample_poly(audio, target_rate // gcd, original_rate // gcd)
+    return resampled.astype(np.int16)
+
+
+@pytest.fixture(scope="session")
+def okay_nabu_audio(piper_voice: piper.PiperVoice) -> np.ndarray:
+    """Generate 'okay nabu' audio as int16 PCM at 16 kHz."""
+    chunks = piper_voice.synthesize("okay nabu")
+    audio_bytes = b"".join(chunk.audio_int16_bytes for chunk in chunks)
+    audio = np.frombuffer(audio_bytes, dtype=np.int16)
+
+    voice_rate = piper_voice.config.sample_rate
+    return _resample(audio, voice_rate, _TARGET_SAMPLE_RATE)

--- a/integration/test_wake_word_detection.py
+++ b/integration/test_wake_word_detection.py
@@ -1,0 +1,95 @@
+"""Integration tests for MicroWakeWord with real TFLite model.
+
+Uses Piper TTS to synthesize wake word audio and feeds it through the
+real okay_nabu.tflite model to verify detection and cooldown behaviour.
+"""
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from private_assistant_comms_satellite.micro_wake_word import MicroWakeWord
+
+_CHUNK_SIZE = 512
+_DETECTION_THRESHOLD = 0.97
+_RELAXED_THRESHOLD = 0.5  # TTS output may not perfectly match natural speech
+
+
+@pytest.fixture()
+def detector(okay_nabu_model_path: pathlib.Path) -> MicroWakeWord:
+    """Create a MicroWakeWord instance with the real okay_nabu model."""
+    return MicroWakeWord(
+        model_path=str(okay_nabu_model_path),
+        sliding_window_size=5,
+        cooldown_chunks=40,
+        rearm_threshold=_DETECTION_THRESHOLD,
+    )
+
+
+def _feed_audio(detector: MicroWakeWord, audio: np.ndarray) -> list[float]:
+    """Feed audio in chunks and return all probabilities."""
+    probabilities: list[float] = []
+    for i in range(0, len(audio), _CHUNK_SIZE):
+        chunk = audio[i : i + _CHUNK_SIZE]
+        if len(chunk) < _CHUNK_SIZE:
+            chunk = np.pad(chunk, (0, _CHUNK_SIZE - len(chunk)))
+        probabilities.append(detector.predict(chunk))
+    return probabilities
+
+
+@pytest.mark.integration
+def test_no_false_positive_on_silence(detector: MicroWakeWord) -> None:
+    """Feeding silence should never exceed the detection threshold."""
+    silence = np.zeros(16_000 * 5, dtype=np.int16)  # 5 seconds
+    probabilities = _feed_audio(detector, silence)
+    assert all(p < _DETECTION_THRESHOLD for p in probabilities), (
+        f"False positive on silence: max={max(probabilities):.4f}"
+    )
+
+
+@pytest.mark.integration
+def test_detects_wake_word(
+    detector: MicroWakeWord,
+    okay_nabu_audio: np.ndarray,
+) -> None:
+    """Piper-synthesized 'okay nabu' should be detected by the model."""
+    # Warm up with a short silence preamble
+    warmup = np.zeros(16_000, dtype=np.int16)  # 1 second
+    _feed_audio(detector, warmup)
+
+    probabilities = _feed_audio(detector, okay_nabu_audio)
+    max_prob = max(probabilities)
+    assert max_prob > _RELAXED_THRESHOLD, f"Model did not respond to TTS wake word: max={max_prob:.4f}"
+
+
+@pytest.mark.integration
+def test_no_retrigger_after_detection(
+    detector: MicroWakeWord,
+    okay_nabu_audio: np.ndarray,
+) -> None:
+    """After detection + cooldown activation, silence must not re-trigger."""
+    # Warm up
+    warmup = np.zeros(16_000, dtype=np.int16)
+    _feed_audio(detector, warmup)
+
+    # Feed wake word audio until detection (or finish the clip)
+    detected = False
+    for i in range(0, len(okay_nabu_audio), _CHUNK_SIZE):
+        chunk = okay_nabu_audio[i : i + _CHUNK_SIZE]
+        if len(chunk) < _CHUNK_SIZE:
+            chunk = np.pad(chunk, (0, _CHUNK_SIZE - len(chunk)))
+        prob = detector.predict(chunk)
+        if prob >= _DETECTION_THRESHOLD:
+            detected = True
+            detector.activate_cooldown()
+            break
+
+    if not detected:
+        pytest.skip("TTS audio did not trigger detection — cannot test re-trigger")
+
+    # Feed 10 seconds of silence after cooldown activation
+    silence = np.zeros(16_000 * 10, dtype=np.int16)
+    probabilities = _feed_audio(detector, silence)
+    max_prob = max(probabilities) if probabilities else 0.0
+    assert max_prob < _DETECTION_THRESHOLD, f"Re-triggered after cooldown: max={max_prob:.4f}"

--- a/local_config.yaml
+++ b/local_config.yaml
@@ -2,9 +2,8 @@
 # This file contains all available configuration options with their default values
 
 # Wake word detection settings
-wakework_detection_threshold: 0.6  # Confidence threshold for wake word detection (0.0-1.0)
-path_or_name_wakeword_model: "./hey_nova.onnx"  # Path to wake word model file
-name_wakeword_model: "hey_nova"  # Name of the wake word model
+wakework_detection_threshold: 0.97  # Confidence threshold for wake word detection (0.0-1.0)
+wakeword_model_path: "./okay_nabu.tflite"  # Path to .tflite wake word model file
 
 # API endpoints for speech processing
 speech_transcription_api: "http://localhost:8000/transcribe"  # STT API endpoint
@@ -25,7 +24,6 @@ max_command_input_seconds: 15     # Maximum recording time for voice commands
 max_length_speech_pause: 1.0      # Maximum pause duration before stopping recording
 samplerate: 16000                 # Audio sample rate in Hz
 chunk_size: 512                   # Audio processing chunk size
-chunk_size_ow: 1280              # OpenWakeWord chunk size
 
 # Voice Activity Detection (VAD)
 vad_threshold: 0.6  # VAD confidence threshold (0.0-1.0, 1.0 is speech)

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,18 +2,11 @@
 warn_return_any = True
 warn_unused_configs = True
 
-[mypy-openwakeword.*]
+[mypy-pymicro_features.*]
+ignore_missing_imports = True
+[mypy-ai_edge_litert.*]
 ignore_missing_imports = True
 [mypy-sounddevice.*]
 ignore_missing_imports = True
 [mypy-soundfile.*]
 ignore_missing_imports = True
-
-# For libraries without type stubs, you can ignore specific imports:
-# Example:
-[mypy-untyped_library.*]
-ignore_missing_imports = True
-#
-# To find type stubs for a library:
-#   uv add --dev types-<library-name>
-# Or check: https://github.com/python/typeshed/tree/main/stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ dependencies = [
     "pyyaml",
     "pydantic",
     "private-assistant-commons~=6.3.0",
-    "speexdsp-ns~=0.1.2",
     "numpy~=2.3.0",
     "websockets~=16.0",
-    "onnxruntime~=1.23.2",
     "pysilero-vad~=3.2.0",
     "typer~=0.21.0",
-    "private-assistant-openwakeword~=0.6.0",
     "sounddevice~=0.5.1",
+    "scipy>=1.14.0",
+    "pymicro-features>=0.1.0",
+    "ai-edge-litert>=1.2.0",
 ]
 
 
@@ -59,4 +59,5 @@ dev = [
     "soundfile~=0.12.1",
     "scipy-stubs~=1.17.0.1",
     "types-pyyaml~=6.0.12.20240311",
+    "piper-tts>=1.2.0",
 ]

--- a/pytest.toml
+++ b/pytest.toml
@@ -5,3 +5,6 @@ testpaths = [
     "tests",
     "integration",
 ]
+markers = [
+    "integration: marks tests that require external resources (models, network)",
+]

--- a/src/private_assistant_comms_satellite/__init__.py
+++ b/src/private_assistant_comms_satellite/__init__.py
@@ -1,2 +1,4 @@
-"""The satellite is an open source library to work with the private assistant oecosystem built to run on edge devices.
-It allows the other components to interact speech based with the user and listen for user keywords to activate."""
+"""Edge device voice interaction library for the private assistant ecosystem.
+
+Provides wake word detection, voice activity detection, and ground station communication.
+"""

--- a/src/private_assistant_comms_satellite/audio_processing.py
+++ b/src/private_assistant_comms_satellite/audio_processing.py
@@ -26,6 +26,7 @@ class ParametricEQ:
             presence_boost_db: Boost at presence frequency in dB (0-6)
             presence_freq_hz: Center frequency for presence (2000-5000 Hz)
             presence_q: Q factor for presence (0.5-5.0, higher = narrower)
+
         """
         self.sample_rate = sample_rate
         self.filters: list[np.ndarray] = []
@@ -57,6 +58,7 @@ class ParametricEQ:
 
         Returns:
             EQ'd audio data
+
         """
         output = audio_chunk.copy()
 
@@ -97,6 +99,7 @@ class SimpleAGC:
             smoothing: Gain smoothing factor (0-0.99, higher = smoother)
             min_gain: Minimum gain factor (prevent over-attenuation)
             max_gain: Maximum gain factor (prevent over-amplification)
+
         """
         self.target_rms = target_rms
         self.smoothing = smoothing
@@ -112,6 +115,7 @@ class SimpleAGC:
 
         Returns:
             Gain-adjusted audio data
+
         """
         # Calculate RMS of current chunk
         rms = np.sqrt(np.mean(audio_chunk**2))

--- a/src/private_assistant_comms_satellite/micro_wake_word.py
+++ b/src/private_assistant_comms_satellite/micro_wake_word.py
@@ -1,0 +1,164 @@
+"""Streaming wake word detection using micro-wake-word TFLite models."""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+
+import numpy as np
+from ai_edge_litert.interpreter import Interpreter
+from pymicro_features import MicroFrontend
+
+logger = logging.getLogger(__name__)
+
+# MicroFrontend processes 160 samples (10ms at 16kHz) per call, as 16-bit PCM bytes
+_SAMPLES_PER_FRAME = 160
+_BYTES_PER_FRAME = _SAMPLES_PER_FRAME * 2
+
+
+class MicroWakeWord:
+    """Streaming wake word detector using TFLite and MicroFrontend.
+
+    Generates spectrogram features incrementally from int16 PCM audio,
+    maintains a ring buffer of features, runs TFLite inference when
+    enough features accumulate, and applies sliding window smoothing.
+
+    Args:
+        model_path: Path to the .tflite wake word model file.
+        sliding_window_size: Number of recent predictions to average for smoothing.
+        cooldown_chunks: Minimum number of low-probability inferences required
+            after activation before detection re-enables (matches ESPHome's
+            ``ignore_windows`` mechanism).
+        rearm_threshold: Raw probability must be below this value for a cooldown
+            step to count. Keeps cooldown active while the model still outputs
+            high probability. Should equal the detection threshold.
+
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        sliding_window_size: int = 5,
+        cooldown_chunks: int = 40,
+        rearm_threshold: float = 0.9,
+    ) -> None:
+        """Initialize the wake word detector with a TFLite model."""
+        self._interpreter = Interpreter(model_path=model_path)
+        self._interpreter.allocate_tensors()
+
+        self._input_details = self._interpreter.get_input_details()
+        self._output_details = self._interpreter.get_output_details()
+
+        # Input shape is [1, time_steps, num_features]
+        self._input_feature_slices: int = int(self._input_details[0]["shape"][1])
+        self._num_features: int = int(self._input_details[0]["shape"][2])
+
+        # Quantization parameters for int8/uint8 models
+        self._input_dtype = self._input_details[0]["dtype"]
+        self._input_scale: float = float(self._input_details[0]["quantization"][0])
+        self._input_zero_point: int = int(self._input_details[0]["quantization"][1])
+        self._output_scale: float = float(self._output_details[0]["quantization"][0])
+        self._output_zero_point: int = int(self._output_details[0]["quantization"][1])
+
+        # Pre-compute clip bounds for quantized input
+        if self._input_dtype != np.float32:
+            info = np.iinfo(self._input_dtype)  # type: ignore[arg-type]
+            self._input_clip_min: float = float(info.min)
+            self._input_clip_max: float = float(info.max)
+
+        self._frontend = MicroFrontend()
+
+        # Ring buffer of spectrogram feature frames
+        self._feature_buffer: deque[list[float]] = deque(maxlen=self._input_feature_slices)
+
+        # Sliding window of recent predictions for smoothing
+        self._prediction_window: deque[float] = deque(maxlen=sliding_window_size)
+
+        # Cooldown / debounce — modelled after ESPHome's ignore_windows mechanism.
+        # After detection the model keeps running inference so its hidden state
+        # stays current, but detection is suppressed until *cooldown_chunks*
+        # consecutive low-probability inferences have been observed.
+        self._cooldown_total = cooldown_chunks
+        self._cooldown_remaining = 0
+        self._rearm_threshold = rearm_threshold
+
+        logger.info(
+            "MicroWakeWord loaded: %d feature slices x %d features, sliding_window=%d, cooldown=%d",
+            self._input_feature_slices,
+            self._num_features,
+            sliding_window_size,
+            cooldown_chunks,
+        )
+
+    def predict(self, audio_int16: np.ndarray) -> float:
+        """Process an int16 PCM audio chunk and return smoothed wake word probability.
+
+        Args:
+            audio_int16: Audio samples as int16 numpy array (any length,
+                typically 512 samples / 32ms at 16kHz).
+
+        Returns:
+            Smoothed probability between 0.0 and 1.0. Returns 0.0 during cooldown
+            or when insufficient features have accumulated.
+
+        """
+        audio_bytes = audio_int16.tobytes()
+        num_bytes = len(audio_bytes)
+        byte_idx = 0
+
+        while byte_idx + _BYTES_PER_FRAME <= num_bytes:
+            result = self._frontend.process_samples(audio_bytes[byte_idx : byte_idx + _BYTES_PER_FRAME])
+            byte_idx += result.samples_read * 2
+            if result.features:
+                self._feature_buffer.append(result.features)
+
+        if len(self._feature_buffer) < self._input_feature_slices:
+            return 0.0
+
+        # Always run inference so the model's internal hidden state stays
+        # current with the audio stream (v2 models are streaming models that
+        # accumulate temporal context through TFLite resource variables).
+        spectrogram = np.array(list(self._feature_buffer), dtype=np.float32)
+
+        # Quantize if model expects integer input (v2 models use int8)
+        if self._input_dtype != np.float32:
+            spectrogram = np.clip(
+                np.round(spectrogram / self._input_scale) + self._input_zero_point,
+                self._input_clip_min,
+                self._input_clip_max,
+            ).astype(self._input_dtype)
+
+        input_tensor = spectrogram.reshape(self._input_details[0]["shape"])
+        self._interpreter.set_tensor(self._input_details[0]["index"], input_tensor)
+        self._interpreter.invoke()
+        raw_output = self._interpreter.get_tensor(self._output_details[0]["index"])
+
+        # Dequantize if model outputs integer (v2 models use uint8)
+        if self._output_details[0]["dtype"] != np.float32:
+            raw_probability = (float(raw_output[0][0]) - self._output_zero_point) * self._output_scale
+        else:
+            raw_probability = float(raw_output[0][0])
+
+        # During cooldown, inference still ran (above) to keep hidden state
+        # fresh, but we suppress detection.  Only count down when the model
+        # outputs low probability — this ensures the model has genuinely
+        # "cooled off" before re-arming (matches ESPHome's ignore_windows).
+        if self._cooldown_remaining > 0:
+            if raw_probability < self._rearm_threshold:
+                self._cooldown_remaining -= 1
+            return 0.0
+
+        self._prediction_window.append(raw_probability)
+        return sum(self._prediction_window) / len(self._prediction_window)
+
+    def activate_cooldown(self) -> None:
+        """Activate cooldown period to prevent repeated detections."""
+        self._cooldown_remaining = self._cooldown_total
+        self._prediction_window.clear()
+
+    def reset(self) -> None:
+        """Reset all internal state."""
+        self._feature_buffer.clear()
+        self._prediction_window.clear()
+        self._cooldown_remaining = 0
+        self._frontend.reset()

--- a/src/private_assistant_comms_satellite/silero_vad.py
+++ b/src/private_assistant_comms_satellite/silero_vad.py
@@ -8,6 +8,7 @@ class SileroVad:
     """Voice activity detection with silero VAD."""
 
     def __init__(self, threshold: float, trigger_level: int) -> None:
+        """Initialize the VAD with detection threshold and trigger level."""
         self.detector = SileroVoiceActivityDetector()
         self.threshold = threshold
         self.trigger_level = trigger_level
@@ -24,6 +25,7 @@ class SileroVad:
 
         Returns:
             True if sustained speech detected above trigger level
+
         """
         # AIDEV-NOTE: VAD reset mechanism for initialization and error recovery
         if audio_array is None:

--- a/src/private_assistant_comms_satellite/utils/__init__.py
+++ b/src/private_assistant_comms_satellite/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for configuration, networking, and audio generation."""

--- a/src/private_assistant_comms_satellite/utils/config.py
+++ b/src/private_assistant_comms_satellite/utils/config.py
@@ -1,3 +1,5 @@
+"""Configuration models and YAML loading."""
+
 import logging
 import socket
 from pathlib import Path
@@ -55,10 +57,12 @@ class AudioProcessingConfig(BaseModel):
 
 
 class Config(BaseModel):
+    """Satellite application configuration."""
+
     wakework_detection_threshold: float = 0.6
-    openwakeword_inference_framework: str = "onnx"
-    path_or_name_wakeword_model: str = "./hey_nova.onnx"
-    name_wakeword_model: str = "hey_nova"
+    wakeword_model_path: str = "./okay_nabu.tflite"
+    wakeword_sliding_window_size: int = Field(default=5, ge=1, le=20)
+    wakeword_cooldown_chunks: int = Field(default=40, ge=1, le=200)
     # AIDEV-NOTE: Ground station WebSocket configuration replaces MQTT and API endpoints
     ground_station_url: str = "ws://localhost:8000/satellite"
     client_id: str = socket.gethostname()
@@ -69,7 +73,6 @@ class Config(BaseModel):
     max_length_speech_pause: float = 1.0
     samplerate: int = 16000
     chunk_size: int = 512
-    chunk_size_ow: int = 1280
     vad_threshold: float = 0.6
     """Silence threshold (0-1, 1 is speech)"""
     vad_trigger: int = 1
@@ -83,6 +86,7 @@ class Config(BaseModel):
 
 
 def load_config(config_path: Path) -> Config:
+    """Load and validate configuration from a YAML file."""
     try:
         with config_path.open("r") as file:
             config_data = yaml.safe_load(file)

--- a/src/private_assistant_comms_satellite/utils/debug_audio.py
+++ b/src/private_assistant_comms_satellite/utils/debug_audio.py
@@ -18,6 +18,7 @@ class AudioRecorder:
 
         Args:
             output_dir: Directory to save audio files
+
         """
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -38,6 +39,7 @@ class AudioRecorder:
 
         Returns:
             Path to saved file
+
         """
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         filename = f"{prefix}_{timestamp}.wav"
@@ -71,6 +73,7 @@ class AudioRecorder:
             processed: Processed audio samples
             sample_rate: Sample rate in Hz
             label: Label for the comparison
+
         """
         self.save_audio(original, sample_rate, f"{label}_original")
         self.save_audio(processed, sample_rate, f"{label}_processed")
@@ -86,6 +89,7 @@ def calculate_snr(signal: np.ndarray, noise: np.ndarray) -> float:
 
     Returns:
         SNR in dB
+
     """
     signal_power = np.mean(signal**2)
     noise_power = np.mean(noise**2)

--- a/src/private_assistant_comms_satellite/utils/sound_generation.py
+++ b/src/private_assistant_comms_satellite/utils/sound_generation.py
@@ -9,7 +9,7 @@ import logging
 import math
 
 import numpy as np
-import numpy.typing as np_typing
+import numpy.typing as npt
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ def generate_sweep(
     duration: float,
     sample_rate: int = 16000,
     amplitude: float = 0.3,
-) -> np_typing.NDArray[np.float32]:
+) -> npt.NDArray[np.float32]:
     """Generate a frequency sweep (chirp) from start to end frequency.
 
     Args:
@@ -32,6 +32,7 @@ def generate_sweep(
 
     Returns:
         Float32 audio array with frequency sweep
+
     """
     # AIDEV-NOTE: Linear frequency sweep with smooth transitions
     num_samples = int(sample_rate * duration)
@@ -59,7 +60,7 @@ def generate_sweep(
         wave[-fade_samples:] *= fade_out
 
     # Keep as float32 for sounddevice
-    wave_float32: np_typing.NDArray[np.float32] = wave.astype(np.float32)
+    wave_float32: npt.NDArray[np.float32] = wave.astype(np.float32)
 
     logger.debug(
         "Generated sweep: %.1f-%.1f Hz, %.2f seconds, %d samples", start_freq, end_freq, duration, len(wave_float32)
@@ -67,7 +68,7 @@ def generate_sweep(
     return wave_float32
 
 
-def generate_start_recording_sound(sample_rate: int = 16000) -> np_typing.NDArray[np.float32]:
+def generate_start_recording_sound(sample_rate: int = 16000) -> npt.NDArray[np.float32]:
     """Generate a pleasant start recording notification sound using upward frequency sweep.
 
     Args:
@@ -75,6 +76,7 @@ def generate_start_recording_sound(sample_rate: int = 16000) -> np_typing.NDArra
 
     Returns:
         Float32 audio array suitable for sounddevice playback
+
     """
     # AIDEV-NOTE: Optimistic upward sweep to signal recording start
     wave = generate_sweep(200, 800, 0.4, sample_rate, amplitude=0.4)
@@ -82,7 +84,7 @@ def generate_start_recording_sound(sample_rate: int = 16000) -> np_typing.NDArra
     return wave
 
 
-def generate_stop_recording_sound(sample_rate: int = 16000) -> np_typing.NDArray[np.float32]:
+def generate_stop_recording_sound(sample_rate: int = 16000) -> npt.NDArray[np.float32]:
     """Generate a pleasant stop recording notification sound using downward frequency sweep.
 
     Args:
@@ -90,6 +92,7 @@ def generate_stop_recording_sound(sample_rate: int = 16000) -> np_typing.NDArray
 
     Returns:
         Float32 audio array suitable for sounddevice playback
+
     """
     # AIDEV-NOTE: Gentle downward sweep to signal recording completion
     wave = generate_sweep(800, 200, 0.4, sample_rate, amplitude=0.4)
@@ -97,7 +100,7 @@ def generate_stop_recording_sound(sample_rate: int = 16000) -> np_typing.NDArray
     return wave
 
 
-def generate_disconnection_warning_sound(sample_rate: int = 16000) -> np_typing.NDArray[np.float32]:
+def generate_disconnection_warning_sound(sample_rate: int = 16000) -> npt.NDArray[np.float32]:
     """Generate a warning sound for disconnection notification.
 
     Creates a distinctive two-tone warning sound to alert the user that
@@ -108,6 +111,7 @@ def generate_disconnection_warning_sound(sample_rate: int = 16000) -> np_typing.
 
     Returns:
         Float32 audio array suitable for sounddevice playback
+
     """
     # AIDEV-NOTE: Two-tone warning pattern to indicate connection issue
     # First tone: lower frequency, shorter
@@ -123,7 +127,7 @@ def generate_disconnection_warning_sound(sample_rate: int = 16000) -> np_typing.
 
     # Combine the tones with gap
     wave = np.concatenate([tone1, gap, tone2])
-    wave_float32: np_typing.NDArray[np.float32] = wave.astype(np.float32)
+    wave_float32: npt.NDArray[np.float32] = wave.astype(np.float32)
 
     logger.info("Generated disconnection warning sound: two-tone pattern, %d samples", len(wave_float32))
     return wave_float32
@@ -131,7 +135,7 @@ def generate_disconnection_warning_sound(sample_rate: int = 16000) -> np_typing.
 
 def generate_default_sounds(
     sample_rate: int = 16000,
-) -> tuple[np_typing.NDArray[np.float32], np_typing.NDArray[np.float32]]:
+) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
     """Generate both start and stop recording sounds using frequency sweeps.
 
     Args:
@@ -139,6 +143,7 @@ def generate_default_sounds(
 
     Returns:
         Tuple of (start_sound_array, stop_sound_array) as float32 arrays
+
     """
     # AIDEV-NOTE: Convenience function for generating paired sweep notification sounds
     start_sound = generate_start_recording_sound(sample_rate)

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -11,7 +11,7 @@ class TestParametricEQ:
     def test_eq_initialization(self):
         """Test EQ can be initialized with valid parameters."""
         eq = ParametricEQ(sample_rate=16000, presence_boost_db=2.5, presence_freq_hz=3500.0)
-        assert eq.sample_rate == 16000  # noqa: PLR2004
+        assert eq.sample_rate == 16000
         assert len(eq.filters) > 0  # At least presence filter
 
     def test_eq_boosts_presence_frequency(self):
@@ -104,7 +104,7 @@ class TestSimpleAGC:
     def test_agc_initialization(self):
         """Test AGC can be initialized."""
         agc = SimpleAGC(target_rms=0.1, smoothing=0.9)
-        assert agc.target_rms == 0.1  # noqa: PLR2004
+        assert agc.target_rms == 0.1
         assert agc.current_gain == 1.0
 
     def test_agc_normalizes_quiet_signal(self):
@@ -149,7 +149,7 @@ class TestSimpleAGC:
         audio = np.random.randn(1000).astype(np.float32) * 0.01
         for i in range(0, len(audio), 512):
             chunk = audio[i : i + 512]
-            if len(chunk) == 512:  # noqa: PLR2004
+            if len(chunk) == 512:
                 agc.process(chunk)
 
         # Gain should have changed

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,12 +16,13 @@ class TestConfig:
         """Test that Config initializes with expected defaults."""
         config = Config()
 
-        assert config.wakework_detection_threshold == 0.6  # noqa: PLR2004
-        assert config.path_or_name_wakeword_model == "./hey_nova.onnx"
-        assert config.name_wakeword_model == "hey_nova"
-        assert config.samplerate == 16000  # noqa: PLR2004
-        assert config.chunk_size == 512  # noqa: PLR2004
-        assert config.vad_threshold == 0.6  # noqa: PLR2004
+        assert config.wakework_detection_threshold == 0.6
+        assert config.wakeword_model_path == "./okay_nabu.tflite"
+        assert config.wakeword_sliding_window_size == 5
+        assert config.wakeword_cooldown_chunks == 40
+        assert config.samplerate == 16000
+        assert config.chunk_size == 512
+        assert config.vad_threshold == 0.6
         assert config.ground_station_url == "ws://localhost:8000/satellite"
 
     def test_config_with_custom_values(self):
@@ -32,8 +33,8 @@ class TestConfig:
             ground_station_url="wss://custom.ground.station/satellite",
         )
 
-        assert config.wakework_detection_threshold == 0.8  # noqa: PLR2004
-        assert config.samplerate == 22050  # noqa: PLR2004
+        assert config.wakework_detection_threshold == 0.8
+        assert config.samplerate == 22050
         assert config.ground_station_url == "wss://custom.ground.station/satellite"
 
 
@@ -55,8 +56,8 @@ ground_station_url: "wss://test.ground.station/satellite"
             config_path = Path(f.name)
             config = load_config(config_path)
 
-            assert config.wakework_detection_threshold == 0.7  # noqa: PLR2004
-            assert config.samplerate == 22050  # noqa: PLR2004
+            assert config.wakework_detection_threshold == 0.7
+            assert config.samplerate == 22050
             assert config.ground_station_url == "wss://test.ground.station/satellite"
 
             # Clean up
@@ -98,8 +99,8 @@ samplerate: -1000
             config = load_config(config_path)
 
             # Should use defaults
-            assert config.wakework_detection_threshold == 0.6  # noqa: PLR2004
-            assert config.samplerate == 16000  # noqa: PLR2004
+            assert config.wakework_detection_threshold == 0.6
+            assert config.samplerate == 16000
 
             # Clean up
             config_path.unlink()

--- a/tests/test_micro_wake_word.py
+++ b/tests/test_micro_wake_word.py
@@ -1,0 +1,285 @@
+"""Tests for MicroWakeWord streaming wake word detector."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from private_assistant_comms_satellite.micro_wake_word import MicroWakeWord
+
+
+def _make_mock_interpreter(input_feature_slices: int = 40, num_features: int = 40):
+    """Create a mock TFLite interpreter with configurable input shape."""
+    mock = MagicMock()
+    mock.get_input_details.return_value = [
+        {
+            "shape": np.array([1, input_feature_slices, num_features]),
+            "index": 0,
+            "dtype": np.float32,
+            "quantization": (0.0, 0),
+        },
+    ]
+    mock.get_output_details.return_value = [
+        {
+            "shape": np.array([1, 1]),
+            "index": 1,
+            "dtype": np.float32,
+            "quantization": (0.0, 0),
+        },
+    ]
+    return mock
+
+
+def _make_mock_frontend_result(features: list[float] | None = None, samples_read: int = 160):
+    """Create a mock MicroFrontendOutput."""
+    result = MagicMock()
+    result.features = features if features is not None else []
+    result.samples_read = samples_read
+    return result
+
+
+class TestMicroWakeWordInit:
+    """Tests for MicroWakeWord initialization."""
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_initialization(self, mock_interpreter_cls, mock_frontend_cls):
+        mock_interpreter_cls.return_value = _make_mock_interpreter(input_feature_slices=50, num_features=40)
+
+        mww = MicroWakeWord(model_path="fake.tflite", sliding_window_size=7, cooldown_chunks=30)
+
+        assert mww._input_feature_slices == 50
+        assert mww._num_features == 40
+        mock_interpreter_cls.return_value.allocate_tensors.assert_called_once()
+        mock_frontend_cls.assert_called_once()
+
+
+class TestMicroWakeWordPredict:
+    """Tests for MicroWakeWord.predict()."""
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_insufficient_features_returns_zero(self, mock_interpreter_cls, mock_frontend_cls):
+        """When not enough features have accumulated, predict returns 0.0."""
+        mock_interpreter = _make_mock_interpreter(input_feature_slices=40)
+        mock_interpreter_cls.return_value = mock_interpreter
+
+        # Frontend returns one feature frame per call (not enough for 40 slices)
+        mock_frontend = MagicMock()
+        mock_frontend.process_samples.return_value = _make_mock_frontend_result(features=[0.1] * 40, samples_read=160)
+        mock_frontend_cls.return_value = mock_frontend
+
+        mww = MicroWakeWord(model_path="fake.tflite")
+
+        # Feed one 512-sample chunk — produces ~3 feature frames, far less than 40
+        audio = np.zeros(512, dtype=np.int16)
+        prob = mww.predict(audio)
+
+        assert prob == 0.0
+        # Interpreter should NOT have been invoked (not enough features)
+        mock_interpreter.invoke.assert_not_called()
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_returns_probability_when_buffer_full(self, mock_interpreter_cls, mock_frontend_cls):
+        """When feature buffer is full, predict runs inference and returns smoothed probability."""
+        mock_interpreter = _make_mock_interpreter(input_feature_slices=3)
+        mock_interpreter_cls.return_value = mock_interpreter
+
+        # Set up interpreter to return probability 0.8
+        mock_interpreter.get_tensor.return_value = np.array([[0.8]], dtype=np.float32)
+
+        # Frontend returns one feature frame per call
+        mock_frontend = MagicMock()
+        mock_frontend.process_samples.return_value = _make_mock_frontend_result(features=[0.5] * 40, samples_read=160)
+        mock_frontend_cls.return_value = mock_frontend
+
+        mww = MicroWakeWord(model_path="fake.tflite", sliding_window_size=3)
+
+        # Feed enough chunks to fill feature buffer (3 slices needed, 3 features per 512-sample chunk)
+        audio = np.zeros(512, dtype=np.int16)
+        prob = mww.predict(audio)
+
+        assert prob == pytest.approx(0.8)
+        mock_interpreter.invoke.assert_called_once()
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_sliding_window_smoothing(self, mock_interpreter_cls, mock_frontend_cls):
+        """Prediction window averages multiple inference results."""
+        mock_interpreter = _make_mock_interpreter(input_feature_slices=2)
+        mock_interpreter_cls.return_value = mock_interpreter
+
+        mock_frontend = MagicMock()
+        mock_frontend.process_samples.return_value = _make_mock_frontend_result(features=[0.5] * 40, samples_read=160)
+        mock_frontend_cls.return_value = mock_frontend
+
+        mww = MicroWakeWord(model_path="fake.tflite", sliding_window_size=3)
+        audio = np.zeros(512, dtype=np.int16)
+
+        # First prediction: 0.6
+        mock_interpreter.get_tensor.return_value = np.array([[0.6]], dtype=np.float32)
+        p1 = mww.predict(audio)
+        assert p1 == pytest.approx(0.6)
+
+        # Second prediction: 0.9 → average of [0.6, 0.9] = 0.75
+        mock_interpreter.get_tensor.return_value = np.array([[0.9]], dtype=np.float32)
+        p2 = mww.predict(audio)
+        assert p2 == pytest.approx(0.75)
+
+        # Third prediction: 0.3 → average of [0.6, 0.9, 0.3] = 0.6
+        mock_interpreter.get_tensor.return_value = np.array([[0.3]], dtype=np.float32)
+        p3 = mww.predict(audio)
+        assert p3 == pytest.approx(0.6)
+
+
+class TestMicroWakeWordCooldown:
+    """Tests for cooldown / debounce behavior."""
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_cooldown_returns_zero_while_running_inference(self, mock_interpreter_cls, mock_frontend_cls):
+        """During cooldown, predict returns 0.0 but inference runs to keep model state current."""
+        mock_interpreter = _make_mock_interpreter(input_feature_slices=2)
+        mock_interpreter_cls.return_value = mock_interpreter
+
+        mock_frontend = MagicMock()
+        mock_frontend.process_samples.return_value = _make_mock_frontend_result(features=[0.5] * 40, samples_read=160)
+        mock_frontend_cls.return_value = mock_frontend
+
+        mww = MicroWakeWord(model_path="fake.tflite", cooldown_chunks=3, rearm_threshold=0.9)
+        audio = np.zeros(512, dtype=np.int16)
+
+        # Fill feature buffer first
+        mock_interpreter.get_tensor.return_value = np.array([[0.9]], dtype=np.float32)
+        mww.predict(audio)
+
+        # Activate cooldown
+        mww.activate_cooldown()
+        mock_interpreter.invoke.reset_mock()
+
+        # During cooldown with low probability: returns 0.0 but DOES run inference
+        mock_interpreter.get_tensor.return_value = np.array([[0.1]], dtype=np.float32)
+        assert mww.predict(audio) == 0.0
+        assert mww.predict(audio) == 0.0
+        assert mww.predict(audio) == 0.0
+        # Inference was called during cooldown (keeps model hidden state current)
+        assert mock_interpreter.invoke.call_count == 3
+
+        # After cooldown expires: detection re-enables
+        mock_interpreter.get_tensor.return_value = np.array([[0.8]], dtype=np.float32)
+        prob = mww.predict(audio)
+        assert prob > 0.0
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_cooldown_only_decrements_on_low_probability(self, mock_interpreter_cls, mock_frontend_cls):
+        """Cooldown stays active when model outputs probability >= rearm_threshold."""
+        mock_interpreter = _make_mock_interpreter(input_feature_slices=2)
+        mock_interpreter_cls.return_value = mock_interpreter
+
+        mock_frontend = MagicMock()
+        mock_frontend.process_samples.return_value = _make_mock_frontend_result(features=[0.5] * 40, samples_read=160)
+        mock_frontend_cls.return_value = mock_frontend
+
+        mww = MicroWakeWord(model_path="fake.tflite", cooldown_chunks=3, rearm_threshold=0.9)
+        audio = np.zeros(512, dtype=np.int16)
+
+        # Fill feature buffer first
+        mock_interpreter.get_tensor.return_value = np.array([[0.9]], dtype=np.float32)
+        mww.predict(audio)
+
+        mww.activate_cooldown()
+        assert mww._cooldown_remaining == 3
+
+        # High probability during cooldown: cooldown does NOT decrement
+        mock_interpreter.get_tensor.return_value = np.array([[0.95]], dtype=np.float32)
+        for _ in range(5):
+            assert mww.predict(audio) == 0.0
+        assert mww._cooldown_remaining == 3  # Unchanged — model still "hot"
+
+        # Low probability: cooldown starts decrementing
+        mock_interpreter.get_tensor.return_value = np.array([[0.1]], dtype=np.float32)
+        mww.predict(audio)
+        assert mww._cooldown_remaining == 2
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_activate_cooldown_clears_prediction_window(self, mock_interpreter_cls, mock_frontend_cls):
+        """activate_cooldown() clears the prediction smoothing window."""
+        mock_interpreter = _make_mock_interpreter(input_feature_slices=2)
+        mock_interpreter_cls.return_value = mock_interpreter
+        mock_interpreter.get_tensor.return_value = np.array([[0.5]], dtype=np.float32)
+
+        mock_frontend = MagicMock()
+        mock_frontend.process_samples.return_value = _make_mock_frontend_result(features=[0.5] * 40, samples_read=160)
+        mock_frontend_cls.return_value = mock_frontend
+
+        mww = MicroWakeWord(model_path="fake.tflite", sliding_window_size=5, cooldown_chunks=1)
+        audio = np.zeros(512, dtype=np.int16)
+
+        # Build up prediction history
+        mww.predict(audio)
+        mww.predict(audio)
+        assert len(mww._prediction_window) == 2
+
+        mww.activate_cooldown()
+        assert len(mww._prediction_window) == 0
+
+
+class TestMicroWakeWordReset:
+    """Tests for reset behavior."""
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_reset_clears_all_state(self, mock_interpreter_cls, mock_frontend_cls):
+        mock_interpreter = _make_mock_interpreter(input_feature_slices=2)
+        mock_interpreter_cls.return_value = mock_interpreter
+        mock_interpreter.get_tensor.return_value = np.array([[0.5]], dtype=np.float32)
+
+        mock_frontend = MagicMock()
+        mock_frontend.process_samples.return_value = _make_mock_frontend_result(features=[0.5] * 40, samples_read=160)
+        mock_frontend_cls.return_value = mock_frontend
+
+        mww = MicroWakeWord(model_path="fake.tflite", cooldown_chunks=10)
+        audio = np.zeros(512, dtype=np.int16)
+
+        # Accumulate state
+        mww.predict(audio)
+        mww.predict(audio)
+        assert len(mww._feature_buffer) > 0
+
+        mww.activate_cooldown()
+        assert mww._cooldown_remaining > 0
+
+        mww.reset()
+
+        assert len(mww._feature_buffer) == 0
+        assert len(mww._prediction_window) == 0
+        assert mww._cooldown_remaining == 0
+        mock_frontend.reset.assert_called_once()
+
+
+class TestMicroWakeWordFeatureBuffer:
+    """Tests for feature ring buffer behavior."""
+
+    @patch("private_assistant_comms_satellite.micro_wake_word.MicroFrontend")
+    @patch("private_assistant_comms_satellite.micro_wake_word.Interpreter")
+    def test_feature_buffer_bounded_by_maxlen(self, mock_interpreter_cls, mock_frontend_cls):
+        """Feature buffer never exceeds input_feature_slices entries."""
+        mock_interpreter = _make_mock_interpreter(input_feature_slices=3)
+        mock_interpreter_cls.return_value = mock_interpreter
+        mock_interpreter.get_tensor.return_value = np.array([[0.5]], dtype=np.float32)
+
+        mock_frontend = MagicMock()
+        mock_frontend.process_samples.return_value = _make_mock_frontend_result(features=[0.5] * 40, samples_read=160)
+        mock_frontend_cls.return_value = mock_frontend
+
+        mww = MicroWakeWord(model_path="fake.tflite")
+        audio = np.zeros(512, dtype=np.int16)
+
+        # Feed many chunks — buffer should stay bounded
+        for _ in range(20):
+            mww.predict(audio)
+
+        assert len(mww._feature_buffer) <= 3

--- a/tests/test_silero_vad.py
+++ b/tests/test_silero_vad.py
@@ -19,8 +19,8 @@ class TestSileroVad:
 
         vad = SileroVad(threshold=0.5, trigger_level=2)
 
-        assert vad.threshold == 0.5  # noqa: PLR2004
-        assert vad.trigger_level == 2  # noqa: PLR2004
+        assert vad.threshold == 0.5
+        assert vad.trigger_level == 2
         assert vad._activation == 0
         assert vad.detector == mock_detector
 
@@ -114,4 +114,4 @@ class TestSileroVad:
         result = vad(audio_data)
 
         assert result is True  # Should trigger because max(0.3, 0.8) = 0.8 > 0.5
-        assert mock_detector.process_samples.call_count == 2  # noqa: PLR2004 - Should process 2 chunks (early termination)
+        assert mock_detector.process_samples.call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,25 @@ revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
+name = "ai-edge-litert"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-strenum" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/59/5f65a091340c6abf26c66a11fc0c8ecbd264e93ad7293aaf1f1b6892cc00/ai_edge_litert-2.1.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:20c96357a7c61600e7ec94a8c131fee4c0a994132e5e6e436c7c7e93d3f31b22", size = 13016970, upload-time = "2026-01-28T07:22:48.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/36/8ff07084091272db4df8de3859149be3913a6eaf2939575bb4200379b808/ai_edge_litert-2.1.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:1b412368980b404aa051d09405abd473d3a15130db030938d26966f1a1e7c413", size = 12633952, upload-time = "2026-01-28T07:05:40.805Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/05/072e76dfa2bfd6aa4c5751f1b6d5ad11f74bba70177ad4c973b49678d4c2/ai_edge_litert-2.1.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:67db6de7c729bbe5a31c20adc573ce47b8aa6ea4b6bcfee0ab77ff1a51e20f2e", size = 16330794, upload-time = "2026-01-28T07:00:09.906Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/6056d84ccd8c64c72ba5dee93402a5ef828058737026b6a820e53c7a6ef2/ai_edge_litert-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:f42037e3b090aa1c85816dab6fd1b58ef34978ae88ea35f435e17f679712aba9", size = 6077276, upload-time = "2026-01-28T09:38:38.97Z" },
+]
+
+[[package]]
 name = "aiomqtt"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -40,12 +59,12 @@ wheels = [
 ]
 
 [[package]]
-name = "certifi"
-version = "2025.11.12"
+name = "backports-strenum"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/c7/2ed54c32fed313591ffb21edbd48db71e68827d43a61938e5a0bc2b6ec91/backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414", size = 7257, upload-time = "2023-12-09T14:36:40.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/50/56cf20e2ee5127b603b81d5a69580a1a325083e2b921aa8f067da83927c0/backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83", size = 8304, upload-time = "2023-12-09T14:36:39.905Z" },
 ]
 
 [[package]]
@@ -72,31 +91,6 @@ wheels = [
 ]
 
 [[package]]
-name = "charset-normalizer"
-version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
-    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
-    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
-    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -115,18 +109,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "coloredlogs"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "humanfriendly" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -175,42 +157,12 @@ wheels = [
 ]
 
 [[package]]
-name = "humanfriendly"
-version = "10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "joblib"
-version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -325,10 +277,9 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.23.2"
+version = "1.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coloredlogs" },
     { name = "flatbuffers" },
     { name = "numpy" },
     { name = "packaging" },
@@ -336,11 +287,10 @@ dependencies = [
     { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/9e/f748cd64161213adeef83d0cb16cb8ace1e62fa501033acdd9f9341fff57/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b8f029a6b98d3cf5be564d52802bb50a8489ab73409fa9db0bf583eabb7c2321", size = 17195929, upload-time = "2025-10-22T03:47:36.24Z" },
-    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/35/4e40f2fba272a6698d62be2cd21ddc3675edfc1a4b9ddefcc4648f115315/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76ff670550dc23e58ea9bc53b5149b99a44e63b34b524f7b8547469aaa0dcb8c", size = 15226915, upload-time = "2025-10-22T03:46:27.773Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/88/9cc25d2bafe6bc0d4d3c1db3ade98196d5b355c0b273e6a5dc09c5d5d0d5/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f9b4ae77f8e3c9bee50c27bc1beede83f786fe1d52e99ac85aa8d65a01e9b77", size = 17382649, upload-time = "2025-10-22T03:47:02.782Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b4/569d298f9fc4d286c11c45e85d9ffa9e877af12ace98af8cab52396e8f46/onnxruntime-1.23.2-cp312-cp312-win_amd64.whl", hash = "sha256:25de5214923ce941a3523739d34a520aac30f21e631de53bba9174dc9c004435", size = 13470528, upload-time = "2025-10-22T03:47:28.106Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/30/437de870e4e1c6d237a2ca5e11f54153531270cb5c745c475d6e3d5c5dcf/onnxruntime-1.24.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:7307aab9e2e879c0171f37e0eb2808a5b4aec7ba899bb17c5f0cedfc301a8ac2", size = 17211043, upload-time = "2026-02-05T17:32:16.909Z" },
+    { url = "https://files.pythonhosted.org/packages/21/60/004401cd86525101ad8aa9eec301327426555d7a77fac89fd991c3c7aae6/onnxruntime-1.24.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:780add442ce2d4175fafb6f3102cdc94243acffa3ab16eacc03dd627cc7b1b54", size = 15016224, upload-time = "2026-02-05T17:30:56.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a1/43ad01b806a1821d1d6f98725edffcdbad54856775643718e9124a09bfbe/onnxruntime-1.24.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34b6119526eda12613f0d0498e2ae59563c247c370c9cef74c2fc93133dde157", size = 17098191, upload-time = "2026-02-05T17:31:31.87Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/37/5beb65270864037d5c8fb25cfe6b23c48b618d1f4d06022d425cbf29bd9c/onnxruntime-1.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:df0af2f1cfcfff9094971c7eb1d1dfae7ccf81af197493c4dc4643e4342c0946", size = 12493108, upload-time = "2026-02-05T17:32:07.076Z" },
 ]
 
 [[package]]
@@ -389,6 +339,22 @@ wheels = [
 ]
 
 [[package]]
+name = "piper-tts"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "onnxruntime" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2f/df92a56383bbfb7a3a35ff539ba4081932bef0daf920ec089ab7269e1493/piper_tts-1.4.1.tar.gz", hash = "sha256:bf0640db9fe512392f0cf570d445f76b3894b29fbab6f81be42b784fd8f0afe0", size = 4364811, upload-time = "2026-02-05T09:58:25.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/1c/e9a6695e19aa5c80b3ac4f70dd432fe3dcf99519458ad149f73af5b0fa44/piper_tts-1.4.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76467df3abe0a0dd8d53e4e7d769ceb1669796e7188954182257be4cf79ddae0", size = 13822406, upload-time = "2026-02-05T09:58:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/633c64944a9ae13d5183989de1519e5eb30e5e6b668942d97ca03b04c53a/piper_tts-1.4.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:a99d93a2eb2805aa7059996069f8448c86ce7704200ec0bf9f9099f035494dc7", size = 13830418, upload-time = "2026-02-05T09:58:15.561Z" },
+    { url = "https://files.pythonhosted.org/packages/df/95/c4c4163cf0f636eec0ccb3adc63c70fb74334ff28e41e176f0ca0415496e/piper_tts-1.4.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3dbc990b4e28c680a44e26dc7a880b3e1068e06ffc1deecc8690929895ffb005", size = 13841987, upload-time = "2026-02-05T09:58:18.259Z" },
+    { url = "https://files.pythonhosted.org/packages/39/42/b44ae16ef80d86173518aafe2a493a826b46f9fe4fba1b82cd575117d5ac/piper_tts-1.4.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5aa533364c15248d2932bcc362eb0740de7cd28dc34233de8df2ee3c6f2adf00", size = 13841873, upload-time = "2026-02-05T09:58:20.428Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d9/bc628449230681cf49af5e289974a076b22e98ecd017108ef0e679be4e00/piper_tts-1.4.1-cp39-abi3-win_amd64.whl", hash = "sha256:058c025f2a929180d034ed8c333f6b9dd286178703be2133efbafba7f4db13ff", size = 13831941, upload-time = "2026-02-05T09:58:22.562Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -420,15 +386,15 @@ name = "private-assistant-comms-satellite"
 version = "1.6.0"
 source = { editable = "." }
 dependencies = [
+    { name = "ai-edge-litert" },
     { name = "numpy" },
-    { name = "onnxruntime" },
     { name = "private-assistant-commons" },
-    { name = "private-assistant-openwakeword" },
     { name = "pydantic" },
+    { name = "pymicro-features" },
     { name = "pysilero-vad" },
     { name = "pyyaml" },
+    { name = "scipy" },
     { name = "sounddevice" },
-    { name = "speexdsp-ns" },
     { name = "typer" },
     { name = "websockets" },
 ]
@@ -436,6 +402,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "piper-tts" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -447,15 +414,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ai-edge-litert", specifier = ">=1.2.0" },
     { name = "numpy", specifier = "~=2.3.0" },
-    { name = "onnxruntime", specifier = "~=1.23.2" },
     { name = "private-assistant-commons", specifier = "~=6.3.0" },
-    { name = "private-assistant-openwakeword", specifier = "~=0.6.0" },
     { name = "pydantic" },
+    { name = "pymicro-features", specifier = ">=0.1.0" },
     { name = "pysilero-vad", specifier = "~=3.2.0" },
     { name = "pyyaml" },
+    { name = "scipy", specifier = ">=1.14.0" },
     { name = "sounddevice", specifier = "~=0.5.1" },
-    { name = "speexdsp-ns", specifier = "~=0.1.2" },
     { name = "typer", specifier = "~=0.21.0" },
     { name = "websockets", specifier = "~=16.0" },
 ]
@@ -463,6 +430,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = "~=1.19.1" },
+    { name = "piper-tts", specifier = ">=1.2.0" },
     { name = "pytest", specifier = "~=9.0.2" },
     { name = "pytest-asyncio", specifier = "~=1.3.0" },
     { name = "pytest-cov", specifier = "~=7.0.0" },
@@ -470,21 +438,6 @@ dev = [
     { name = "scipy-stubs", specifier = "~=1.17.0.1" },
     { name = "soundfile", specifier = "~=0.12.1" },
     { name = "types-pyyaml", specifier = "~=6.0.12.20240311" },
-]
-
-[[package]]
-name = "private-assistant-openwakeword"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-    { name = "scikit-learn" },
-    { name = "scipy" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/ca/57c314ca874443575d27aa0ceb121a6a5f8f3f45117146db483dedbb4bad/private_assistant_openwakeword-0.6.0.tar.gz", hash = "sha256:fb94e45e89b77f525e9b3d527a5cb50916bd2afc376bd92da31bb0a1369f2234", size = 71776, upload-time = "2025-07-29T17:33:57.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/e9/fd5b9dc682586af6b195b8680cf68d348a7977224ae8f3699266950fd17c/private_assistant_openwakeword-0.6.0-py3-none-any.whl", hash = "sha256:45cb7322185bac0cdcf5ca66793b1fe44fc975468048c7439d7ec378fd41ec89", size = 61407, upload-time = "2025-07-29T17:33:56.245Z" },
 ]
 
 [[package]]
@@ -579,12 +532,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pyreadline3"
-version = "3.5.4"
+name = "pymicro-features"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/46/328092b4df890385594cf3d3e6015da72d77f63c58d3057276ac2353e891/pymicro_features-2.0.2.tar.gz", hash = "sha256:0d0bed7843ec78b6ced82d1a2dcddeb4fe5df61b3af80a281d0868c8e279c727", size = 54713, upload-time = "2025-10-09T21:14:13.135Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b1/511149e0ab3b244eedd8ba0d4f5293e2f1558f9e06a5c8724efb265e467b/pymicro_features-2.0.2-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:a8f8b115cf825c44c7a1fddc0af154e2fb0c52f8d1a4597e1f1a113b91ff8324", size = 42354, upload-time = "2025-10-09T21:14:08.552Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/34/c52065f422c009d99c434fb68918142b815055942fcb57c9533810a22080/pymicro_features-2.0.2-cp39-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acead36386b42934e620f57d7481177ba461dde247cccef6a846f5831805e6c7", size = 116415, upload-time = "2025-10-09T21:14:09.6Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/30/a31c5dc56015e55f897d0beb71447f1e10f0062067258856f3735ede133a/pymicro_features-2.0.2-cp39-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:65a76a7c7851ee0dd6083dda56b835ab9dc6eddeaf11b34461795758de846d0f", size = 119607, upload-time = "2025-10-09T21:14:10.734Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/22/577100459a7d3e7f5b3c5315c6c546a7980bf711371ca36398f440a1aee4/pymicro_features-2.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:e76b656ce6a2eab9571657bbecaf17a5c07830306f9b544fbbea16c567bd78fb", size = 22695, upload-time = "2025-10-09T21:14:12.152Z" },
 ]
 
 [[package]]
@@ -670,21 +626,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.32.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -724,44 +665,24 @@ wheels = [
 ]
 
 [[package]]
-name = "scikit-learn"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "joblib" },
-    { name = "numpy" },
-    { name = "scipy" },
-    { name = "threadpoolctl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
-    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
-    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
-    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
-]
-
-[[package]]
 name = "scipy"
-version = "1.16.3"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/41/5bf55c3f386b1643812f3a5674edf74b26184378ef0f3e7c7a09a7e2ca7f/scipy-1.16.3-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:81fc5827606858cf71446a5e98715ba0e11f0dbc83d71c7409d05486592a45d6", size = 36659043, upload-time = "2025-10-28T17:32:40.285Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/0f/65582071948cfc45d43e9870bf7ca5f0e0684e165d7c9ef4e50d783073eb/scipy-1.16.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:c97176013d404c7346bf57874eaac5187d969293bf40497140b0a2b2b7482e07", size = 28898986, upload-time = "2025-10-28T17:32:45.325Z" },
-    { url = "https://files.pythonhosted.org/packages/96/5e/36bf3f0ac298187d1ceadde9051177d6a4fe4d507e8f59067dc9dd39e650/scipy-1.16.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2b71d93c8a9936046866acebc915e2af2e292b883ed6e2cbe5c34beb094b82d9", size = 20889814, upload-time = "2025-10-28T17:32:49.277Z" },
-    { url = "https://files.pythonhosted.org/packages/80/35/178d9d0c35394d5d5211bbff7ac4f2986c5488b59506fef9e1de13ea28d3/scipy-1.16.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:3d4a07a8e785d80289dfe66b7c27d8634a773020742ec7187b85ccc4b0e7b686", size = 23565795, upload-time = "2025-10-28T17:32:53.337Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/46/d1146ff536d034d02f83c8afc3c4bab2eddb634624d6529a8512f3afc9da/scipy-1.16.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0553371015692a898e1aa858fed67a3576c34edefa6b7ebdb4e9dde49ce5c203", size = 33349476, upload-time = "2025-10-28T17:32:58.353Z" },
-    { url = "https://files.pythonhosted.org/packages/79/2e/415119c9ab3e62249e18c2b082c07aff907a273741b3f8160414b0e9193c/scipy-1.16.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:72d1717fd3b5e6ec747327ce9bda32d5463f472c9dce9f54499e81fbd50245a1", size = 35676692, upload-time = "2025-10-28T17:33:03.88Z" },
-    { url = "https://files.pythonhosted.org/packages/27/82/df26e44da78bf8d2aeaf7566082260cfa15955a5a6e96e6a29935b64132f/scipy-1.16.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1fb2472e72e24d1530debe6ae078db70fb1605350c88a3d14bc401d6306dbffe", size = 36019345, upload-time = "2025-10-28T17:33:09.773Z" },
-    { url = "https://files.pythonhosted.org/packages/82/31/006cbb4b648ba379a95c87262c2855cd0d09453e500937f78b30f02fa1cd/scipy-1.16.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5192722cffe15f9329a3948c4b1db789fbb1f05c97899187dcf009b283aea70", size = 38678975, upload-time = "2025-10-28T17:33:15.809Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/7f/acbd28c97e990b421af7d6d6cd416358c9c293fc958b8529e0bd5d2a2a19/scipy-1.16.3-cp312-cp312-win_amd64.whl", hash = "sha256:56edc65510d1331dae01ef9b658d428e33ed48b4f77b1d51caf479a0253f96dc", size = 38555926, upload-time = "2025-10-28T17:33:21.388Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/69/c5c7807fd007dad4f48e0a5f2153038dc96e8725d3345b9ee31b2b7bed46/scipy-1.16.3-cp312-cp312-win_arm64.whl", hash = "sha256:a8a26c78ef223d3e30920ef759e25625a0ecdd0d60e5a8818b7513c3e5384cf2", size = 25463014, upload-time = "2025-10-28T17:33:25.975Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/11/7241a63e73ba5a516f1930ac8d5b44cbbfabd35ac73a2d08ca206df007c4/scipy-1.17.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:0d5018a57c24cb1dd828bcf51d7b10e65986d549f52ef5adb6b4d1ded3e32a57", size = 31364580, upload-time = "2026-01-10T21:25:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1d/5057f812d4f6adc91a20a2d6f2ebcdb517fdbc87ae3acc5633c9b97c8ba5/scipy-1.17.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:88c22af9e5d5a4f9e027e26772cc7b5922fab8bcc839edb3ae33de404feebd9e", size = 27969012, upload-time = "2026-01-10T21:25:30.921Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/21/f6ec556c1e3b6ec4e088da667d9987bb77cc3ab3026511f427dc8451187d/scipy-1.17.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:f3cd947f20fe17013d401b64e857c6b2da83cae567adbb75b9dcba865abc66d8", size = 20140691, upload-time = "2026-01-10T21:25:34.802Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/5e5ad04784964ba964a96f16c8d4676aa1b51357199014dce58ab7ec5670/scipy-1.17.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e8c0b331c2c1f531eb51f1b4fc9ba709521a712cce58f1aa627bc007421a5306", size = 22463015, upload-time = "2026-01-10T21:25:39.277Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/69/7c347e857224fcaf32a34a05183b9d8a7aca25f8f2d10b8a698b8388561a/scipy-1.17.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5194c445d0a1c7a6c1a4a4681b6b7c71baad98ff66d96b949097e7513c9d6742", size = 32724197, upload-time = "2026-01-10T21:25:44.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/fe/66d73b76d378ba8cc2fe605920c0c75092e3a65ae746e1e767d9d020a75a/scipy-1.17.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9eeb9b5f5997f75507814ed9d298ab23f62cf79f5a3ef90031b1ee2506abdb5b", size = 35009148, upload-time = "2026-01-10T21:25:50.591Z" },
+    { url = "https://files.pythonhosted.org/packages/af/07/07dec27d9dc41c18d8c43c69e9e413431d20c53a0339c388bcf72f353c4b/scipy-1.17.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:40052543f7bbe921df4408f46003d6f01c6af109b9e2c8a66dd1cf6cf57f7d5d", size = 34798766, upload-time = "2026-01-10T21:25:59.41Z" },
+    { url = "https://files.pythonhosted.org/packages/81/61/0470810c8a093cdacd4ba7504b8a218fd49ca070d79eca23a615f5d9a0b0/scipy-1.17.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0cf46c8013fec9d3694dc572f0b54100c28405d55d3e2cb15e2895b25057996e", size = 37405953, upload-time = "2026-01-10T21:26:07.75Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ce/672ed546f96d5d41ae78c4b9b02006cedd0b3d6f2bf5bb76ea455c320c28/scipy-1.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:0937a0b0d8d593a198cededd4c439a0ea216a3f36653901ea1f3e4be949056f8", size = 36328121, upload-time = "2026-01-10T21:26:16.509Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/21/38165845392cae67b61843a52c6455d47d0cc2a40dd495c89f4362944654/scipy-1.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:f603d8a5518c7426414d1d8f82e253e454471de682ce5e39c29adb0df1efb86b", size = 24314368, upload-time = "2026-01-10T21:26:23.087Z" },
 ]
 
 [[package]]
@@ -819,15 +740,6 @@ wheels = [
 ]
 
 [[package]]
-name = "speexdsp-ns"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/7e/1b7f7f021736c671b18d69f6f561d5556fd3a5369c94d9c458b4a8fb2e13/speexdsp_ns-0.1.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:09cf0a8f9530fca1f203f53808b074d247b9083df323199bd9d150f70af08338", size = 158227, upload-time = "2023-08-07T20:34:52.144Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/14/d9fd843472f82853643c4ae09835c76bfb19ce7e712586cfc1318030503f/speexdsp_ns-0.1.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c2c73c2f132212fecfff52a689594f925453ff521fec336411149256aedcd819", size = 161569, upload-time = "2023-08-07T20:34:59.781Z" },
-]
-
-[[package]]
 name = "sqlalchemy"
 version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
@@ -869,15 +781,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
-name = "threadpoolctl"
-version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -935,15 +838,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\n\n- Migrate wake word detection from openwakeword (ONNX) to micro-wake-word (TFLite) for lower latency and better edge device compatibility\n- New `MicroWakeWord` class uses `MicroFrontend` for incremental spectrogram generation, a ring buffer of features, and sliding window smoothing\n- Fix re-trigger loop bug by always running inference during cooldown (keeps v2 model hidden state current) with conditional cooldown decrement matching ESPHome's `streaming_model.cpp` reference implementation\n- Add Piper TTS integration tests that synthesize wake word audio and verify detection, silence rejection, and no re-trigger after cooldown\n\n## Key design decisions\n\n- **Always run inference during cooldown**: V2 micro-wake-word models are streaming models with internal hidden state (TFLite resource variables). Skipping `invoke()` during cooldown froze the hidden state, causing re-triggers on silence.\n- **Conditional cooldown**: Cooldown only decrements when raw probability drops below `rearm_threshold`, ensuring the model has genuinely \"cooled off\" before re-arming.\n\n## Test plan\n\n- [x] Unit tests for MicroWakeWord (predict, cooldown, sliding window, reset, feature buffer)\n- [x] Integration tests with real okay_nabu.tflite model via Piper TTS\n- [x] Verified on edge device — no re-trigger loop\n\nCloses #56